### PR TITLE
joyent/node-krill#5: add support for getting a map of field names to values

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ console.log('fields: ', predicate.fields().join(', '));
 /* Prints: "hostname, latency" */
 ```
 
+You can also get access to an object that represents a map between field names
+and the lists of values used for each field name in this predicate:
+
+```javascript
+/* Output the map between field names and their values */
+console.log('field names to values: ' + predicate.fieldsAndValues());
+/* Prints: { hostname: [ 'spike' ], latency: [ 300 ] } */
+```
+
 You can also print a C-syntax expression for this predicate, which you can
 actually plug directly into a C-like language (like JavaScript) to evaluate it:
 

--- a/lib/krill.js
+++ b/lib/krill.js
@@ -2,7 +2,7 @@
  * krill.js: utilities related to handling and processing boolean predicates.
  */
 
-var mod_assert = require('assert');
+var mod_assert = require('assert-plus');
 var mod_stream = require('stream');
 var mod_util = require('util');
 
@@ -74,6 +74,28 @@ Predicate.prototype.fields = function ()
 		fields[subpred[key][0]] = true;
 	}, this.p_pred);
 	return (Object.keys(fields));
+};
+
+/*
+ * Returns a map of fields to a list of values referenced in this predicate for
+ * these fields.
+ */
+Predicate.prototype.fieldsAndValues = function ()
+{
+	var fieldNamesToValues = {};
+
+	krillPrimWalk(function (subpred, key) {
+		var valuesList = fieldNamesToValues[subpred[key][0]];
+		var value = subpred[key][1];
+		if (valuesList === undefined) {
+			fieldNamesToValues[subpred[key][0]] = [ value ];
+		} else {
+			mod_assert.array(valuesList, 'valuesList');
+			valuesList.push(value);
+		}
+	}, this.p_pred);
+
+	return (fieldNamesToValues);
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-	"name": "krill",
-	"description": "simple boolean filter language",
-	"version": "0.3.0",
-	"license": "MIT",
-	"contributors": [
-	    "Robert Mustacchi <rm@joyent.com>",
-	    "Dave Pacheco <dap@joyent.com>"
-	],
-	"repository": {
-	    "type": "git",
-	    "url": "http://github.com/joyent/node-krill.git"
-	},
-	"main": "lib/krill.js",
-	"dependencies": {
-	    "extsprintf": "1.0.2",
-	    "jsprim": "0.5.1",
-	    "verror": "1.3.6"
-	}
+  "name": "krill",
+  "description": "simple boolean filter language",
+  "version": "0.3.0",
+  "license": "MIT",
+  "contributors": [
+    "Robert Mustacchi <rm@joyent.com>",
+    "Dave Pacheco <dap@joyent.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/joyent/node-krill.git"
+  },
+  "main": "lib/krill.js",
+  "dependencies": {
+    "assert-plus": "1.0.0",
+    "extsprintf": "1.0.2",
+    "jsprim": "0.5.1",
+    "verror": "1.3.6"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "krill",
-  "description": "simple boolean filter language",
-  "version": "0.3.0",
-  "license": "MIT",
-  "contributors": [
-    "Robert Mustacchi <rm@joyent.com>",
-    "Dave Pacheco <dap@joyent.com>"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/joyent/node-krill.git"
-  },
-  "main": "lib/krill.js",
-  "dependencies": {
-    "assert-plus": "1.0.0",
-    "extsprintf": "1.0.2",
-    "jsprim": "0.5.1",
-    "verror": "1.3.6"
-  }
+	"name": "krill",
+	"description": "simple boolean filter language",
+	"version": "0.3.0",
+	"license": "MIT",
+	"contributors": [
+	    "Robert Mustacchi <rm@joyent.com>",
+	    "Dave Pacheco <dap@joyent.com>"
+	],
+	"repository": {
+	    "type": "git",
+	    "url": "http://github.com/joyent/node-krill.git"
+	},
+	"main": "lib/krill.js",
+	"dependencies": {
+	    "assert-plus": "1.0.0",
+	    "extsprintf": "1.0.2",
+	    "jsprim": "0.5.1",
+	    "verror": "1.3.6"
+	}
 }

--- a/tests/tst.basic.js
+++ b/tests/tst.basic.js
@@ -13,6 +13,7 @@ var pred;
 pred = mod_krill.createPredicate({});
 mod_assert.ok(pred.trivial());
 mod_assert.deepEqual([], pred.fields());
+mod_assert.deepEqual({}, pred.fieldsAndValues());
 mod_assert.equal('1', pred.toCStyleString());
 mod_assert.ok(pred.eval({}));
 mod_assert.ok(pred.eval({ 'hostname': 'sharptooth' }));
@@ -25,6 +26,7 @@ pred = mod_krill.createPredicate(
     { 'zonename': 'string' });
 mod_assert.ok(!pred.trivial());
 mod_assert.deepEqual([ 'zonename' ], pred.fields());
+mod_assert.deepEqual({ zonename: [ 'bar' ] }, pred.fieldsAndValues());
 mod_assert.equal('zonename == "bar"', pred.toCStyleString());
 mod_assert.throws(function () { pred.eval({}); }, /no translation/);
 mod_assert.ok(pred.eval({ 'zonename': 'bar' }));
@@ -47,6 +49,11 @@ pred = mod_krill.createPredicate({
 mod_assert.ok(!pred.trivial());
 mod_assert.deepEqual([ 'hostname', 'latency', 'zonename' ],
     pred.fields().sort());
+mod_assert.deepEqual({
+    zonename: [ 'bar' ],
+    hostname: [ 'sharptooth' ],
+    latency: [ 15 ]
+}, pred.fieldsAndValues());
 mod_assert.equal('(zonename == "bar") && (hostname != "sharptooth") && ' +
     '(latency >= 15)', pred.toCStyleString());
 mod_assert.throws(function () { pred.eval({}); }, /no translation/);
@@ -107,6 +114,10 @@ pred = mod_krill.createPredicate({
 });
 mod_assert.ok(!pred.trivial());
 mod_assert.deepEqual([ 'count', 'latency' ], pred.fields().sort());
+mod_assert.deepEqual({
+    count: [ 15 ],
+    latency: [ 10, 20 ]
+}, pred.fieldsAndValues());
 mod_assert.equal('(latency < 10) || (count <= 15) || (latency > 20)',
     pred.toCStyleString());
 mod_assert.ok(pred.eval({ 'latency': 9, 'count': 20 }));


### PR DESCRIPTION
This is a work in progress. If that looks good, then I imagine we'll want to bump at least the minor version number in `package.json` at some point