### PR TITLE
joyent/node-krill#8: toLDAPFilterString returns invalid LDAP search filter for empty predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ console.log('LDAP search filter: ', predicate.toLDAPFilterString());
 /* Prints "(|(hostname=spike)(latency>300))" */
 ```
 
-Please note however that trivial predicates cannot be serialized to LDAP search
-filters:
+Please note however that without knowing the LDAP object schema, it is not
+possible to generate a filter that matches all objects. As a result, trivial
+predicates cannot be serialized as LDAP search filters:
 
 ```javascript
 var pred = krill.createPredicate({});

--- a/README.md
+++ b/README.md
@@ -83,6 +83,35 @@ console.log('LDAP search filter: ', predicate.toLDAPFilterString());
 /* Prints "(|(hostname=spike)(latency>300))" */
 ```
 
+Please note however that trivial predicates cannot be serialized to LDAP search
+filters:
+
+```javascript
+var pred = krill.createPredicate({});
+pred.toLDAPSearchFilter();
+/* Throws the following error:
+Error: Cannot serialize empty predicate to LDAP search filter
+*/
+```
+
+The recommended way to handle this case is to check if the predicate is trivial
+before calling `toLDAPSearchFilter`:
+
+```javascript
+var pred = krill.createPredicate({});
+var ldapSearchFilter;
+if (!pred.trivial()) {
+    ldapSearchFilter = pred.toLDAPFilterString();
+} else {
+    /*
+     * This example assumes that when the predicate is trivial, the intention
+     * is to build a LDAP search filter that includes all entries, but this is
+     * done only to illustrate a common use case.
+     */
+    ldapSearchFilter = '(someRDN=*)';
+}
+```
+
 You can also evaluate the predicate for a specific set of values:
 
 ```javascript

--- a/lib/krill.js
+++ b/lib/krill.js
@@ -70,6 +70,11 @@ Predicate.prototype.toCStyleString = function ()
  */
 Predicate.prototype.toLDAPFilterString = function ()
 {
+	if (this.trivial()) {
+		throw new Error('Cannot serialize empty predicate to LDAP '
+		    + 'search filter');
+	}
+
 	return (krillPrimPrintLDAP(this.p_pred));
 };
 
@@ -624,8 +629,10 @@ function krillPrimPrintLDAP(pred) {
 	var key = sanityCheckResult.key;
 	var nbKeys = sanityCheckResult.nbKeys;
 
-	if (nbKeys === 0)
-		return ('(*)');
+	// Serializing an individual predicate with a number of keys !== 1 --
+	// that is an empty predicate, or a predicate with several keys -- to a
+	// LDAP filter string is not supported.
+	mod_assert(nbKeys === 1);
 
 	return (krillOps[key].printLDAP(pred, key));
 }

--- a/lib/krill.js
+++ b/lib/krill.js
@@ -629,9 +629,11 @@ function krillPrimPrintLDAP(pred) {
 	var key = sanityCheckResult.key;
 	var nbKeys = sanityCheckResult.nbKeys;
 
-	// Serializing an individual predicate with a number of keys !== 1 --
-	// that is an empty predicate, or a predicate with several keys -- to a
-	// LDAP filter string is not supported.
+	/*
+	 * Serializing an individual predicate with a number of keys !== 1 --
+	 * that is an empty predicate, or a predicate with several keys -- to a
+	 * LDAP filter string is not supported.
+	 */
 	mod_assert(nbKeys === 1);
 
 	return (krillOps[key].printLDAP(pred, key));

--- a/tests/tst.basic.js
+++ b/tests/tst.basic.js
@@ -15,7 +15,9 @@ mod_assert.ok(pred.trivial());
 mod_assert.deepEqual([], pred.fields());
 mod_assert.deepEqual({}, pred.fieldsAndValues());
 mod_assert.equal('1', pred.toCStyleString());
-mod_assert.equal('(*)', pred.toLDAPFilterString());
+mod_assert.throws(function emptyPredToLDAPFilter() {
+    pred.toLDAPFilterString()
+}, /Cannot serialize empty predicate to LDAP search filter/);
 mod_assert.ok(pred.eval({}));
 mod_assert.ok(pred.eval({ 'hostname': 'sharptooth' }));
 


### PR DESCRIPTION
Fixes #8.

/cc @davepacheco @rmustacc